### PR TITLE
Fix base64 encoding

### DIFF
--- a/enricher/enricher.go
+++ b/enricher/enricher.go
@@ -69,7 +69,7 @@ func (enr *enricher) enrichRecord(r map[interface{}]interface{}, t time.Time) ma
 		return r
 	}
 
-	resource := map[string]interface{}{
+	resource := map[interface{}]interface{}{
 		"cloud.account.id":      enr.canvaAWSAccount,
 		"service.name":          enr.canvaAppName,
 		"cloud.platform":        "aws_ecs",

--- a/enricher/enricher_test.go
+++ b/enricher/enricher_test.go
@@ -43,7 +43,7 @@ func Test_enricher_enrichRecord(t *testing.T) {
 				time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC),
 			},
 			want: map[interface{}]interface{}{
-				"resource": map[string]interface{}{
+				"resource": map[interface{}]interface{}{
 					"cloud.account.id":      "canva_aws_account_val",
 					"service.name":          "canva_app_name_val",
 					"cloud.platform":        "aws_ecs",


### PR DESCRIPTION
There is a code in https://github.com/aws/amazon-kinesis-firehose-for-fluent-bit/blob/v1.5.1/plugins/plugins.go#L153
Which is used in the kinesis-streams plugin.
```go
// DecodeMap prepares a record for JSON marshalling
// Any []byte will be base64 encoded when marshaled to JSON, so we must directly cast all []byte to string
func DecodeMap(record map[interface{}]interface{}) (map[interface{}]interface{}, error) {
	for k, v := range record {
		switch t := v.(type) {
		case []byte:
			// convert all byte slices to strings
			record[k] = string(t)
		case map[interface{}]interface{}:
			decoded, err := DecodeMap(t)
			if err != nil {
				return nil, err
			}
			record[k] = decoded
		case []interface{}:
			decoded, err := decodeSlice(t)
			if err != nil {
				return nil, err
			}
			record[k] = decoded
		}
	}
	return record, nil
}
```

This one does recursive decoding to string.
But it is only sensitive to `map[interface{}]interface{}` and `[]interface{}`, and in our code, we were using `map[string]interface{}`.