### PR TITLE
Copy compressed buffer bytes

### DIFF
--- a/compress/gzip/gzip.go
+++ b/compress/gzip/gzip.go
@@ -61,5 +61,8 @@ func (z *GZip) Compress(data []byte) ([]byte, error) {
 		return data, err
 	}
 
-	return tmpBuffer.Bytes(), nil
+	bufferBytes := tmpBuffer.Bytes()
+	result := make([]byte, len(bufferBytes))
+	copy(result, bufferBytes)
+	return result, nil
 }

--- a/compress/gzip/gzip_test.go
+++ b/compress/gzip/gzip_test.go
@@ -77,3 +77,37 @@ func TestGZip_Compress(t *testing.T) {
 		})
 	}
 }
+
+func TestBufferReuse(t *testing.T) {
+	compress1Want := []byte{31, 139, 8, 0, 0, 0, 0, 0, 4, 255, 0, 3, 0, 252, 255, 1, 2, 3, 1, 0, 0, 255, 255, 29, 128, 188, 85, 3, 0, 0, 0}
+	compress2Want := []byte{31, 139, 8, 0, 0, 0, 0, 0, 4, 255, 0, 5, 0, 250, 255, 4, 5, 6, 7, 8, 1, 0, 0, 255, 255, 168, 195, 107, 65, 5, 0, 0, 0}
+	compress3Want := []byte{31, 139, 8, 0, 0, 0, 0, 0, 4, 255, 0, 2, 0, 253, 255, 9, 10, 1, 0, 0, 255, 255, 168, 64, 206, 112, 2, 0, 0, 0}
+
+	z, err := New(1)
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+
+	compressed1, err := z.Compress([]byte{1, 2, 3})
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+	compressed2, err := z.Compress([]byte{4, 5, 6, 7, 8})
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+	compressed3, err := z.Compress([]byte{9, 10})
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+
+	if !bytes.Equal(compressed1, compress1Want) {
+		t.Errorf("compressed1 got %v, want %v ", compressed1, compress1Want)
+	}
+	if !bytes.Equal(compressed2, compress2Want) {
+		t.Errorf("compressed2 got %v, want %v ", compressed2, compress2Want)
+	}
+	if !bytes.Equal(compressed3, compress3Want) {
+		t.Errorf("compressed3 got %v, want %v ", compressed3, compress3Want)
+	}
+}

--- a/compress/zstd/zstd.go
+++ b/compress/zstd/zstd.go
@@ -66,5 +66,8 @@ func (z *ZSTD) Compress(data []byte) ([]byte, error) {
 		return data, err
 	}
 
-	return tmpBuffer.Bytes(), nil
+	bufferBytes := tmpBuffer.Bytes()
+	result := make([]byte, len(bufferBytes))
+	copy(result, bufferBytes)
+	return result, nil
 }

--- a/compress/zstd/zstd_test.go
+++ b/compress/zstd/zstd_test.go
@@ -84,3 +84,37 @@ func TestZSTD_Compress(t *testing.T) {
 		})
 	}
 }
+
+func TestBufferReuse(t *testing.T) {
+	compress1Want := []byte{40, 181, 47, 253, 4, 0, 25, 0, 0, 1, 2, 3, 165, 229, 78, 12}
+	compress2Want := []byte{40, 181, 47, 253, 4, 0, 41, 0, 0, 4, 5, 6, 7, 8, 41, 208, 126, 18}
+	compress3Want := []byte{40, 181, 47, 253, 4, 0, 17, 0, 0, 9, 10, 235, 159, 206, 197}
+
+	z, err := New(1)
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+
+	compressed1, err := z.Compress([]byte{1, 2, 3})
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+	compressed2, err := z.Compress([]byte{4, 5, 6, 7, 8})
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+	compressed3, err := z.Compress([]byte{9, 10})
+	if err != nil {
+		t.Errorf("New() error = %v", err)
+	}
+
+	if !bytes.Equal(compressed1, compress1Want) {
+		t.Errorf("compressed1 got %v, want %v ", compressed1, compress1Want)
+	}
+	if !bytes.Equal(compressed2, compress2Want) {
+		t.Errorf("compressed2 got %v, want %v ", compressed2, compress2Want)
+	}
+	if !bytes.Equal(compressed3, compress3Want) {
+		t.Errorf("compressed3 got %v, want %v ", compressed3, compress3Want)
+	}
+}


### PR DESCRIPTION
A new bug introduced in https://github.com/Canva/amazon-kinesis-streams-for-fluent-bit/pull/5

Since `compressedData` was no longer copied, when there is a put request with more than one aggregate, each aggregation overwrite the previous ones.