### PR TITLE
Support EKS enricher

### DIFF
--- a/enricher/ecs/ecs.go
+++ b/enricher/ecs/ecs.go
@@ -1,0 +1,101 @@
+// Package ecs is an implementation of Enricher interface using ECS environment.
+package ecs
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ECS implements Enricher interface for ECS environment.
+type ECS struct {
+	canvaAWSAccount string
+	canvaAppName    string
+	logGroup        string
+	ecsTaskFamily   string
+	ecsTaskRevision int
+}
+
+// New returns an ECS enricher.
+func New() *ECS {
+	ecsTaskDefinition := os.Getenv("ECS_TASK_DEFINITION")
+	re := regexp.MustCompile(`^(?P<ecs_task_family>[^ ]*):(?P<ecs_task_revision>[\d]+)$`)
+	ecsTaskDefinitionParts := re.FindStringSubmatch(ecsTaskDefinition)
+	var (
+		ecsTaskFamily   string
+		ecsTaskRevision int
+	)
+	ecsTaskFamilyIndex := re.SubexpIndex("ecs_task_family")
+	ecsTaskRevisionIndex := re.SubexpIndex("ecs_task_revision")
+
+	if len(ecsTaskDefinitionParts) >= ecsTaskFamilyIndex {
+		ecsTaskFamily = ecsTaskDefinitionParts[ecsTaskFamilyIndex]
+	}
+	if len(ecsTaskDefinitionParts) >= ecsTaskRevisionIndex {
+		var err error
+		ecsTaskRevision, err = strconv.Atoi(ecsTaskDefinitionParts[re.SubexpIndex("ecs_task_revision")])
+		if err != nil {
+			logrus.Warnf("[kinesis] ecs_task_revision not found for ECS_TASK_DEFINITION=%s", ecsTaskDefinition)
+		}
+	}
+
+	return &ECS{
+		canvaAWSAccount: os.Getenv("CANVA_AWS_ACCOUNT"),
+		canvaAppName:    os.Getenv("CANVA_APP_NAME"),
+		logGroup:        os.Getenv("LOG_GROUP"),
+		ecsTaskFamily:   ecsTaskFamily,
+		ecsTaskRevision: ecsTaskRevision,
+	}
+}
+
+// EnrichRecord modifies existing record.
+func (enr *ECS) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[interface{}]interface{} {
+	resource := map[interface{}]interface{}{
+		"cloud.account.id":      enr.canvaAWSAccount,
+		"service.name":          enr.canvaAppName,
+		"cloud.platform":        "aws_ecs",
+		"aws.ecs.launchtype":    "EC2",
+		"aws.ecs.task.family":   enr.ecsTaskFamily,
+		"aws.ecs.task.revision": enr.ecsTaskRevision,
+		"aws.log.group.names":   enr.logGroup,
+	}
+	body := make(map[interface{}]interface{})
+
+	var (
+		ok        bool
+		strKey    string
+		timestamp interface{}
+	)
+	for k, v := range r {
+		strKey, ok = k.(string)
+		if ok {
+			switch strKey {
+			case "ecs_task_definition":
+				// Skip
+			case "timestamp":
+				timestamp = v
+			case "ec2_instance_id":
+				resource["host.id"] = v
+			case "ecs_cluster":
+				resource["aws.ecs.cluster.name"] = v
+			case "ecs_task_arn":
+				resource["aws.ecs.task.arn"] = v
+			case "container_id":
+				resource["container.id"] = v
+			case "container_name":
+				resource["container.name"] = v
+			default:
+				body[k] = v
+			}
+		}
+	}
+	return map[interface{}]interface{}{
+		"resource":          resource,
+		"body":              body,
+		"timestamp":         timestamp,
+		"observedTimestamp": t.UnixMilli(),
+	}
+}

--- a/enricher/ecs/ecs_test.go
+++ b/enricher/ecs/ecs_test.go
@@ -1,0 +1,107 @@
+package ecs
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	want := &ECS{
+		canvaAWSAccount: "test_account",
+		canvaAppName:    "test_app_name",
+		logGroup:        "test_log_group",
+		ecsTaskFamily:   "test_ecs_task_family",
+		ecsTaskRevision: 10001,
+	}
+	t.Setenv("CANVA_AWS_ACCOUNT", "test_account")
+	t.Setenv("CANVA_APP_NAME", "test_app_name")
+	t.Setenv("LOG_GROUP", "test_log_group")
+	t.Setenv("ECS_TASK_DEFINITION", "test_ecs_task_family:10001")
+	if got := New(); !reflect.DeepEqual(got, want) {
+		t.Errorf("New() = %v, want %v", got, want)
+	}
+}
+
+func TestECS_EnrichRecord(t *testing.T) {
+	type fields struct {
+		canvaAWSAccount string
+		canvaAppName    string
+		logGroup        string
+		ecsTaskFamily   string
+		ecsTaskRevision int
+	}
+	type args struct {
+		r map[interface{}]interface{}
+		t time.Time
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[interface{}]interface{}
+	}{
+		{
+			"all_values",
+			fields{
+				"canva_aws_account_val",
+				"canva_app_name_val",
+				"log_group_val",
+				"ecs_task_family_val",
+				10001,
+			},
+			args{
+				map[interface{}]interface{}{
+					"ec2_instance_id":     "ec2_instance_id_val",
+					"ecs_cluster":         "ecs_cluster_val",
+					"ecs_task_arn":        "ecs_task_arn_val",
+					"container_id":        "container_id_val",
+					"container_name":      "container_name_val",
+					"other_key_1":         "other_value_1",
+					"other_key_2":         "other_value_2",
+					"other_key_3":         "other_value_3",
+					"timestamp":           "1234567890",
+					"ecs_task_definition": "ecs_task_definition_val",
+				},
+				time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC),
+			},
+			map[interface{}]interface{}{
+				"resource": map[interface{}]interface{}{
+					"cloud.account.id":      "canva_aws_account_val",
+					"service.name":          "canva_app_name_val",
+					"cloud.platform":        "aws_ecs",
+					"aws.ecs.launchtype":    "EC2",
+					"aws.ecs.task.family":   "ecs_task_family_val",
+					"aws.ecs.task.revision": 10001,
+					"aws.log.group.names":   "log_group_val",
+					"host.id":               "ec2_instance_id_val",
+					"aws.ecs.cluster.name":  "ecs_cluster_val",
+					"aws.ecs.task.arn":      "ecs_task_arn_val",
+					"container.id":          "container_id_val",
+					"container.name":        "container_name_val",
+				},
+				"body": map[interface{}]interface{}{
+					"other_key_1": "other_value_1",
+					"other_key_2": "other_value_2",
+					"other_key_3": "other_value_3",
+				},
+				"timestamp":         "1234567890",
+				"observedTimestamp": int64(1257894425432),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enr := &ECS{
+				canvaAWSAccount: tt.fields.canvaAWSAccount,
+				canvaAppName:    tt.fields.canvaAppName,
+				logGroup:        tt.fields.logGroup,
+				ecsTaskFamily:   tt.fields.ecsTaskFamily,
+				ecsTaskRevision: tt.fields.ecsTaskRevision,
+			}
+			if got := enr.EnrichRecord(tt.args.r, tt.args.t); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ECS.EnrichRecord() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -1,0 +1,74 @@
+// Package eks is an implementation of Enricher interface using EKS environment.
+package eks
+
+import (
+	"os"
+	"time"
+)
+
+// EKS implements Enricher interface for EKS environment.
+type EKS struct {
+	canvaAWSAccount string
+}
+
+// New returns an EKS enricher.
+func New() *EKS {
+	return &EKS{
+		canvaAWSAccount: os.Getenv("CANVA_AWS_ACCOUNT"),
+	}
+}
+
+// EnrichRecord modifies existing record.
+func (enr *EKS) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[interface{}]interface{} {
+	res := newResource(enr.canvaAWSAccount)
+
+	var (
+		ok     bool
+		strKey string
+		body   interface{}
+	)
+
+	for k, v := range r {
+		strKey, ok = k.(string)
+		if ok {
+			switch strKey {
+			case "body":
+				body = v
+			case "kubernetes":
+				res.extractFromKubeTags(v)
+			case "labels":
+				res.extractFromLabelsTags(v)
+			default:
+				// Skip
+				// "stream": "stderr"
+				// "time":   "2022-11-15T05:30:18.573672299Z"
+			}
+		}
+	}
+
+	return map[interface{}]interface{}{
+		"resource":          map[interface{}]interface{}(res),
+		"body":              body,
+		"timestamp":         extractTimestampFromBody(body),
+		"observedTimestamp": t.UnixMilli(),
+	}
+}
+
+// extractTimestampFromBody extracts and removes timestamp from log body.
+func extractTimestampFromBody(body interface{}) interface{} {
+	bodyMap, ok := body.(map[interface{}]interface{})
+	if !ok {
+		return nil
+	}
+
+	var strKey string
+	for k, v := range bodyMap {
+		strKey, ok = k.(string)
+		if ok && strKey == "timestamp" {
+			delete(bodyMap, k)
+			return v
+		}
+	}
+
+	return nil
+}

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -1,0 +1,162 @@
+package eks
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	want := &EKS{
+		canvaAWSAccount: "test_account",
+	}
+	t.Setenv("CANVA_AWS_ACCOUNT", "test_account")
+	if got := New(); !reflect.DeepEqual(got, want) {
+		t.Errorf("New() = %v, want %v", got, want)
+	}
+}
+
+func TestEKS_EnrichRecord(t *testing.T) {
+	type fields struct {
+		canvaAWSAccount string
+	}
+	type args struct {
+		r map[interface{}]interface{}
+		t time.Time
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[interface{}]interface{}
+	}{
+		{
+			"service_pod",
+			fields{
+				"test_account",
+			},
+			args{
+				map[interface{}]interface{}{
+					"body": map[interface{}]interface{}{
+						"other_key_1": "other_value_1",
+						"other_key_2": "other_value_2",
+						"other_key_3": "other_value_3",
+						"timestamp":   "1234567890",
+					},
+					"kubernetes": map[interface{}]interface{}{
+						"host":            "test_host_id",
+						"docker_id":       "test_container_id",
+						"container_name":  "test_container_name",
+						"namespace_name":  "test_namespace_name",
+						"pod_name":        "test_pod_name",
+						"pod_id":          "test_pod_id",
+						"container_hash":  "test_container_hash",
+						"container_image": "test_container_image",
+					},
+					"labels": map[interface{}]interface{}{
+						"canva.component":      "test_canva_component",
+						"app":                  "deploy-exploration-worker",
+						"canva.flavor":         "dev",
+						"canva.platform":       "eks",
+						"canva.application-id": "deploy-exploration",
+						"name":                 "deploy-exploration-worker",
+						"deploymentstack":      "new",
+					},
+					"stream": "stderr",
+					"time":   "2022-11-15T05:30:18.573672299Z",
+				},
+				time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC),
+			},
+			map[interface{}]interface{}{
+				"resource": map[interface{}]interface{}{
+					"cloud.platform":     "aws_eks",
+					"cloud.account.id":   "test_account",
+					"host.id":            "test_host_id",
+					"container.id":       "test_container_id",
+					"container.name":     "test_container_name",
+					"k8s.namespace.name": "test_namespace_name",
+					"k8s.pod.name":       "test_pod_name",
+					"k8s.pod.uid":        "test_pod_id",
+					"service.name":       "test_canva_component",
+				},
+				"body": map[interface{}]interface{}{
+					"other_key_1": "other_value_1",
+					"other_key_2": "other_value_2",
+					"other_key_3": "other_value_3",
+				},
+				"timestamp":         "1234567890",
+				"observedTimestamp": int64(1257894425432),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enr := &EKS{
+				canvaAWSAccount: tt.fields.canvaAWSAccount,
+			}
+			if got := enr.EnrichRecord(tt.args.r, tt.args.t); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("EKS.EnrichRecord() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractTimestampFromBody(t *testing.T) {
+	type args struct {
+		body interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		want     interface{}
+		wantBody interface{}
+	}{
+		{
+			"not_found",
+			args{
+				map[interface{}]interface{}{
+					"key_1": "val_1",
+					"key_2": "val_2",
+				},
+			},
+			nil,
+			map[interface{}]interface{}{
+				"key_1": "val_1",
+				"key_2": "val_2",
+			},
+		},
+		{
+			"found",
+			args{
+				map[interface{}]interface{}{
+					"key_1":     "val_1",
+					"key_2":     "val_2",
+					"timestamp": "1234567890",
+				},
+			},
+			"1234567890",
+			map[interface{}]interface{}{
+				"key_1": "val_1",
+				"key_2": "val_2",
+			},
+		},
+		{
+			"invalid_type",
+			args{
+				"string",
+			},
+			nil,
+			"string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractTimestampFromBody(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractTimestampFromBody() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args.body, tt.wantBody) {
+				t.Errorf("extractTimestampFromBody().body = %v, want %v", tt.args.body, tt.wantBody)
+			}
+		})
+	}
+}

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -78,6 +78,7 @@ func TestEKS_EnrichRecord(t *testing.T) {
 					"k8s.pod.name":       "test_pod_name",
 					"k8s.pod.uid":        "test_pod_id",
 					"service.name":       "test_canva_component",
+					"canva.flavor":       "dev",
 				},
 				"body": map[interface{}]interface{}{
 					"other_key_1": "other_value_1",

--- a/enricher/eks/resource.go
+++ b/enricher/eks/resource.go
@@ -58,6 +58,8 @@ func (res resource) extractFromLabelsTags(tags interface{}) {
 			switch strKey {
 			case "canva.component":
 				res["service.name"] = v
+			case "canva.flavor":
+				res["canva.flavor"] = v
 			default:
 				// Skip
 			}

--- a/enricher/eks/resource.go
+++ b/enricher/eks/resource.go
@@ -1,0 +1,66 @@
+package eks
+
+// resource holds and operates over resource values.
+type resource map[interface{}]interface{}
+
+// newResource creates a new resource with initial values.
+func newResource(awsAccount string) resource {
+	return map[interface{}]interface{}{
+		"cloud.platform":   "aws_eks",
+		"cloud.account.id": awsAccount,
+	}
+}
+
+// extractFromKubeTags extracts kubernetes tags values and add them to resource.
+func (res resource) extractFromKubeTags(tags interface{}) {
+	tagsMap, ok := tags.(map[interface{}]interface{})
+	if !ok {
+		return
+	}
+
+	var strKey string
+	for k, v := range tagsMap {
+		strKey, ok = k.(string)
+		if ok {
+			switch strKey {
+			case "host":
+				res["host.id"] = v
+			case "docker_id":
+				res["container.id"] = v
+			case "container_name":
+				res["container.name"] = v
+			case "namespace_name":
+				res["k8s.namespace.name"] = v
+			case "pod_name":
+				res["k8s.pod.name"] = v
+			case "pod_id":
+				res["k8s.pod.uid"] = v
+			default:
+				// Skip
+				// "container_hash":  "k8s.gcr.io/etcd@sha256:13f53ed1d91e2e11aac476ee9a0269fdda6cc4874eba903efd40daf50c55eee5"
+				// "container_image": "k8s.gcr.io/etcd:3.5.3-0"
+			}
+		}
+	}
+}
+
+// extractFromLabelsTags extracts labels tags values and add them to resource.
+func (res resource) extractFromLabelsTags(tags interface{}) {
+	tagsMap, ok := tags.(map[interface{}]interface{})
+	if !ok {
+		return
+	}
+
+	var strKey string
+	for k, v := range tagsMap {
+		strKey, ok = k.(string)
+		if ok {
+			switch strKey {
+			case "canva.component":
+				res["service.name"] = v
+			default:
+				// Skip
+			}
+		}
+	}
+}

--- a/enricher/eks/resource_test.go
+++ b/enricher/eks/resource_test.go
@@ -1,0 +1,126 @@
+package eks
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_newResource(t *testing.T) {
+	const accountID = "testAccountID"
+	want := resource{
+		"cloud.platform":   "aws_eks",
+		"cloud.account.id": accountID,
+	}
+	got := newResource(accountID)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("newResource() = %v, want %v", got, want)
+	}
+}
+
+func Test_resource_extractFromKubeTags(t *testing.T) {
+	type args struct {
+		tags interface{}
+	}
+	tests := []struct {
+		name         string
+		res          resource
+		args         args
+		wantResource resource
+	}{
+		{
+			"service_pod",
+			resource{},
+			args{
+				map[interface{}]interface{}{
+					"host":            "test_host_id",
+					"docker_id":       "test_container_id",
+					"container_name":  "test_container_name",
+					"namespace_name":  "test_namespace_name",
+					"pod_name":        "test_pod_name",
+					"pod_id":          "test_pod_id",
+					"container_hash":  "test_container_hash",
+					"container_image": "test_container_image",
+				},
+			},
+			resource{
+				"host.id":            "test_host_id",
+				"container.id":       "test_container_id",
+				"container.name":     "test_container_name",
+				"k8s.namespace.name": "test_namespace_name",
+				"k8s.pod.name":       "test_pod_name",
+				"k8s.pod.uid":        "test_pod_id",
+			},
+		},
+		{
+			"invalid_type",
+			resource{
+				"key_1": "val_1",
+			},
+			args{
+				"string",
+			},
+			resource{
+				"key_1": "val_1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.res.extractFromKubeTags(tt.args.tags)
+			if !reflect.DeepEqual(tt.res, tt.wantResource) {
+				t.Errorf("EKS.extractFromKubeTags().resource = %v, want %v", tt.res, tt.wantResource)
+			}
+		})
+	}
+}
+
+func Test_resource_extractFromLabelsTags(t *testing.T) {
+	type args struct {
+		tags interface{}
+	}
+	tests := []struct {
+		name         string
+		res          resource
+		args         args
+		wantResource resource
+	}{
+		{
+			"service_pod",
+			resource{},
+			args{
+				map[interface{}]interface{}{
+					"canva.component":      "test_canva_component",
+					"app":                  "deploy-exploration-worker",
+					"canva.flavor":         "dev",
+					"canva.platform":       "eks",
+					"canva.application-id": "deploy-exploration",
+					"name":                 "deploy-exploration-worker",
+					"deploymentstack":      "new",
+				},
+			},
+			resource{
+				"service.name": "test_canva_component",
+			},
+		},
+		{
+			"invalid_type",
+			resource{
+				"key_1": "val_1",
+			},
+			args{
+				"string",
+			},
+			resource{
+				"key_1": "val_1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.res.extractFromLabelsTags(tt.args.tags)
+			if !reflect.DeepEqual(tt.res, tt.wantResource) {
+				t.Errorf("EKS.extractFromLabelsTags().resource = %v, want %v", tt.res, tt.wantResource)
+			}
+		})
+	}
+}

--- a/enricher/eks/resource_test.go
+++ b/enricher/eks/resource_test.go
@@ -100,6 +100,7 @@ func Test_resource_extractFromLabelsTags(t *testing.T) {
 			},
 			resource{
 				"service.name": "test_canva_component",
+				"canva.flavor": "dev",
 			},
 		},
 		{

--- a/enricher/noop/noop.go
+++ b/enricher/noop/noop.go
@@ -1,0 +1,17 @@
+// Package noop is an implementation of Enricher interface that doesn't modify records.
+package noop
+
+import "time"
+
+// Noop is an implementation of Enricher interface that doesn't modify records.
+type Noop struct{}
+
+// New creates a new instance of Noop.
+func New() Noop {
+	return Noop{}
+}
+
+// EnrichRecord will return record without any modifying it.
+func (enr Noop) EnrichRecord(r map[interface{}]interface{}, _ time.Time) map[interface{}]interface{} {
+	return r
+}

--- a/enricher/noop/noop_test.go
+++ b/enricher/noop/noop_test.go
@@ -1,0 +1,49 @@
+package noop
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	// Nothing to check, no panic is enough for this test.
+	_ = New()
+}
+
+func TestNoop_EnrichRecord(t *testing.T) {
+	type args struct {
+		r   map[interface{}]interface{}
+		in1 time.Time
+	}
+	tests := []struct {
+		name string
+		enr  Noop
+		args args
+		want map[interface{}]interface{}
+	}{
+		{
+			"noop",
+			Noop{},
+			args{
+				map[interface{}]interface{}{
+					"k1": 1,
+					2:    "v2",
+				},
+				time.Now(),
+			},
+			map[interface{}]interface{}{
+				"k1": 1,
+				2:    "v2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enr := Noop{}
+			if got := enr.EnrichRecord(tt.args.r, tt.args.in1); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Noop.EnrichRecord() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[High-level Design Doc](https://docs.google.com/document/d/1E_qnIaW1qsgmlMtgov6T-_4ZzvRzpWYSUX3Fuw9bnrs)

Changed enricher to interface and moved ECS enricher under its own package.
Two new enrichers were introduced:

1. Noop: To replace `enrich_records = off`
2. EKS: to support EKS environment.

Config changes:
1. `enrich_records` (bool-optional) dropped
2. `enriched` (string-optional) introduced with 3 values: `noop`, `ecs`, `eks`