### PR TITLE
OLED-332 - Drop log if log field is empty in EKS enricher

### DIFF
--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -27,6 +27,11 @@ func NewEnricher() (*Enricher, error) {
 var _ enricher.IEnricher = (*Enricher)(nil)
 
 func (e Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[interface{}]interface{} {
+	// Drop log if "log" field is empty
+	if r["log"] == nil {
+		return nil
+	}
+
 	// add resource attributes
 	r["resource"] = map[interface{}]interface{}{
 		mappings.RESOURCE_CLOUD_ACCOUNT_ID: e.AccountId,

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -104,6 +104,17 @@ func TestEnrichRecords(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Drop Log If Log Field Is Empty",
+			Enricher: Enricher{
+				AccountId:            DummyAccountId,
+				CanvaAccountFunction: DummyAccountFunction,
+			},
+			Input: map[interface{}]interface{}{
+				"observedTimestamp": DummyTime,
+			},
+			Expected: nil,
+		},
 	}
 
 	for _, c := range cases {

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -342,12 +342,15 @@ func unpackRecords(kinesisOutput *kinesis.OutputPlugin, data unsafe.Pointer, len
 
 		record = enr.EnrichRecord(record, timestamp)
 
-		retCode := kinesisOutput.AddRecord(&records, record, &timestamp)
-		if retCode != output.FLB_OK {
-			return nil, 0, retCode
-		}
+		// If it is not dropped, addw
+		if record != nil {
+			retCode := kinesisOutput.AddRecord(&records, record, &timestamp)
+			if retCode != output.FLB_OK {
+				return nil, 0, retCode
+			}
 
-		count++
+			count++
+		}
 	}
 
 	if kinesisOutput.IsAggregate() {

--- a/fluent-bit-kinesis.go
+++ b/fluent-bit-kinesis.go
@@ -342,7 +342,7 @@ func unpackRecords(kinesisOutput *kinesis.OutputPlugin, data unsafe.Pointer, len
 
 		record = enr.EnrichRecord(record, timestamp)
 
-		// If it is not dropped, addw
+		// If it is not dropped, push to kinesis and increment count
 		if record != nil {
 			retCode := kinesisOutput.AddRecord(&records, record, &timestamp)
 			if retCode != output.FLB_OK {


### PR DESCRIPTION
*Issue #, if available:*


The logs pipeline enricher is unable to drop logs, so we have to drop logs in fluent-bit.

I attempted to do the following in the tail input component:
`Skip_Empty_Lines  On`
But this did not work.

So we have to drop it in the KDS output plugin.

I tested this by emitting an empty log to the datadog agent log file by doing the following:

`echo "2023-03-21T03:45:00.958158093Z stdout F " >> datadog-gq9gr_addons_agent-9d70c216f2370827e3f8b091e311e016eb33e71581bbc01ae412b8670c52f213.log`

If it errored, it would have shown up on this [issue](https://canva.sentry.io/issues/3968781018/?project=5931331&query=is%3Aunresolved&referrer=issue-stream).

After testing this change in `telemetry-test`, emitting the log above does not error in the enricher anymore.

*Description of changes:*
Drop log record if `log` field is empty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
