### PR TITLE
Add placeholder kubernetes.container_name if log not enriched

### DIFF
--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -3,6 +3,7 @@ package eks
 import (
 	"time"
 
+	"github.com/caarlos0/env/v7"
 	"github.com/canva/amazon-kinesis-streams-for-fluent-bit/enricher"
 	"github.com/canva/amazon-kinesis-streams-for-fluent-bit/enricher/mappings"
 )

--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -42,8 +42,8 @@ func (e Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[i
 
 	// If Fluentbit has failed to enrich k8s metadata on the log, we insert a placeholder value for the kubernetes.service_name
 	// https://docs.google.com/document/d/1vRCUKMeo6ypnAq34iwQN7LtDsXxmlj0aYEfRofwV7A4/edit
-	if _, ok := r["kubernetes"]; !ok {
-		r["kubernetes"] = map[interface{}]interface{}{
+	if _, ok := r[mappings.KUBERNETES_RESOURCE_FIELD_NAME]; !ok {
+		r[mappings.KUBERNETES_RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
 			mappings.KUBERNETES_CONTAINER_NAME: mappings.PLACEHOLDER_MISSING_KUBERNETES_METADATA,
 		}
 	}

--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -3,7 +3,6 @@ package eks
 import (
 	"time"
 
-	"github.com/caarlos0/env/v7"
 	"github.com/canva/amazon-kinesis-streams-for-fluent-bit/enricher"
 	"github.com/canva/amazon-kinesis-streams-for-fluent-bit/enricher/mappings"
 )
@@ -39,6 +38,14 @@ func (e Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[i
 	}
 
 	r[mappings.OBSERVED_TIMESTAMP] = t.UnixMilli()
+
+	// If Fluentbit has failed to enrich k8s metadata on the log, we insert a placeholder value for the kubernetes.service_name
+	// https://docs.google.com/document/d/1vRCUKMeo6ypnAq34iwQN7LtDsXxmlj0aYEfRofwV7A4/edit
+	if _, ok := r["kubernetes"]; !ok {
+		r["kubernetes"] = map[interface{}]interface{}{
+			mappings.KUBERNETES_CONTAINER_NAME: mappings.PLACEHOLDER_MISSING_KUBERNETES_METADATA,
+		}
+	}
 
 	return r
 }

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -144,10 +144,10 @@ func TestEnrichRecords(t *testing.T) {
 				"log":                       "hello world",
 				"resource": map[interface{}]interface{}{
 					mappings.RESOURCE_CLOUD_ACCOUNT_ID: DummyAccountId,
-					mappings.RESOURCE_ACCOUNT_GROUP:    "PII",
+					mappings.RESOURCE_ACCOUNT_GROUP:    DummyAccountFunction,
 				},
 				"kubernetes": map[interface{}]interface{}{
-					"container_name": "_missing_metadata",
+					mappings.KUBERNETES_CONTAINER_NAME: mappings.PLACEHOLDER_MISSING_KUBERNETES_METADATA,
 				},
 			},
 		},

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -76,6 +76,9 @@ func TestEnrichRecords(t *testing.T) {
 			},
 			Input: map[interface{}]interface{}{
 				"log": "hello world",
+				"kubernetes": map[interface{}]interface{}{
+					"key": "value",
+				},
 			},
 			Expected: map[interface{}]interface{}{
 				mappings.OBSERVED_TIMESTAMP: ExpectedTime,
@@ -83,6 +86,9 @@ func TestEnrichRecords(t *testing.T) {
 				"resource": map[interface{}]interface{}{
 					mappings.RESOURCE_CLOUD_ACCOUNT_ID: "1234567",
 					mappings.RESOURCE_ACCOUNT_GROUP:    DummyAccountFunction,
+				},
+				"kubernetes": map[interface{}]interface{}{
+					"key": "value",
 				},
 			},
 		},
@@ -94,6 +100,9 @@ func TestEnrichRecords(t *testing.T) {
 			},
 			Input: map[interface{}]interface{}{
 				"log": "hello world",
+				"kubernetes": map[interface{}]interface{}{
+					"key": "value",
+				},
 			},
 			Expected: map[interface{}]interface{}{
 				mappings.OBSERVED_TIMESTAMP: ExpectedTime,
@@ -101,6 +110,9 @@ func TestEnrichRecords(t *testing.T) {
 				"resource": map[interface{}]interface{}{
 					mappings.RESOURCE_CLOUD_ACCOUNT_ID: DummyAccountId,
 					mappings.RESOURCE_ACCOUNT_GROUP:    "PII",
+				},
+				"kubernetes": map[interface{}]interface{}{
+					"key": "value",
 				},
 			},
 		},
@@ -112,8 +124,32 @@ func TestEnrichRecords(t *testing.T) {
 			},
 			Input: map[interface{}]interface{}{
 				"observedTimestamp": DummyTime,
+				"kubernetes": map[interface{}]interface{}{
+					"key": "value",
+				},
 			},
 			Expected: nil,
+		},
+		{
+			Name: "Enrich placeholder service name if kubernetes dict is empty",
+			Enricher: Enricher{
+				AccountId:            DummyAccountId,
+				CanvaAccountFunction: DummyAccountFunction,
+			},
+			Input: map[interface{}]interface{}{
+				"log": "hello world",
+			},
+			Expected: map[interface{}]interface{}{
+				mappings.OBSERVED_TIMESTAMP: ExpectedTime,
+				"log":                       "hello world",
+				"resource": map[interface{}]interface{}{
+					mappings.RESOURCE_CLOUD_ACCOUNT_ID: DummyAccountId,
+					mappings.RESOURCE_ACCOUNT_GROUP:    "PII",
+				},
+				"kubernetes": map[interface{}]interface{}{
+					"container_name": "_missing_metadata",
+				},
+			},
 		},
 	}
 

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -76,7 +76,7 @@ func TestEnrichRecords(t *testing.T) {
 			},
 			Input: map[interface{}]interface{}{
 				"log": "hello world",
-				"kubernetes": map[interface{}]interface{}{
+				mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 					"key": "value",
 				},
 			},
@@ -87,7 +87,7 @@ func TestEnrichRecords(t *testing.T) {
 					mappings.RESOURCE_CLOUD_ACCOUNT_ID: "1234567",
 					mappings.RESOURCE_ACCOUNT_GROUP:    DummyAccountFunction,
 				},
-				"kubernetes": map[interface{}]interface{}{
+				mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 					"key": "value",
 				},
 			},
@@ -100,7 +100,7 @@ func TestEnrichRecords(t *testing.T) {
 			},
 			Input: map[interface{}]interface{}{
 				"log": "hello world",
-				"kubernetes": map[interface{}]interface{}{
+				mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 					"key": "value",
 				},
 			},
@@ -111,7 +111,7 @@ func TestEnrichRecords(t *testing.T) {
 					mappings.RESOURCE_CLOUD_ACCOUNT_ID: DummyAccountId,
 					mappings.RESOURCE_ACCOUNT_GROUP:    "PII",
 				},
-				"kubernetes": map[interface{}]interface{}{
+				mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 					"key": "value",
 				},
 			},
@@ -124,7 +124,7 @@ func TestEnrichRecords(t *testing.T) {
 			},
 			Input: map[interface{}]interface{}{
 				"observedTimestamp": DummyTime,
-				"kubernetes": map[interface{}]interface{}{
+				mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 					"key": "value",
 				},
 			},
@@ -146,7 +146,7 @@ func TestEnrichRecords(t *testing.T) {
 					mappings.RESOURCE_CLOUD_ACCOUNT_ID: DummyAccountId,
 					mappings.RESOURCE_ACCOUNT_GROUP:    DummyAccountFunction,
 				},
-				"kubernetes": map[interface{}]interface{}{
+				mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 					mappings.KUBERNETES_CONTAINER_NAME: mappings.PLACEHOLDER_MISSING_KUBERNETES_METADATA,
 				},
 			},

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -5,6 +5,7 @@ const (
 )
 
 const (
+	KUBERNETES_RESOURCE_FIELD_NAME          = "kubernetes"
 	KUBERNETES_CONTAINER_NAME               = "container_name"
 	PLACEHOLDER_MISSING_KUBERNETES_METADATA = "_missing_metadata"
 )

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -5,6 +5,11 @@ const (
 )
 
 const (
+	KUBERNETES_CONTAINER_NAME               = "container_name"
+	PLACEHOLDER_MISSING_KUBERNETES_METADATA = "_missing_metadata"
+)
+
+const (
 	RESOURCE_CLOUD_ACCOUNT_ID = "cloud.account.id"
 	RESOURCE_ACCOUNT_GROUP    = "canva.account.function"
 )


### PR DESCRIPTION

A small subset of logs are failing to be enriched with metadata before being pushed to Kinesis. This is causing failures downstream in the logging pipeline.

Investigation RE enrichment failures: https://docs.google.com/document/d/1vRCUKMeo6ypnAq34iwQN7LtDsXxmlj0aYEfRofwV7A4/edit

To workaround this, we enrich the log with a placeholder service_name so that we can still track the error but allow the logging pipeline to gracefully succeed.
