### PR TITLE
Add additional check for "msg" for skip log

### DIFF
--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -35,7 +35,7 @@ var _ enricher.IEnricher = (*Enricher)(nil)
 
 func (e Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[interface{}]interface{} {
 	// Drop log if "log" field is empty
-	if r[mappings.LOG_FIELD_NAME] == nil {
+	if r[mappings.LOG_FIELD_NAME] == nil && r[mappings.MSG_FIELD_NAME] == nil {
 		return nil
 	}
 

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -6,7 +6,7 @@ const (
 
 const (
 	LOG_FIELD_NAME = "log"
-	MSG_FIELD_NAME = "msg"
+	MSG_FIELD_NAME = "message"
 )
 
 const (

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -6,6 +6,7 @@ const (
 
 const (
 	LOG_FIELD_NAME = "log"
+	MSG_FIELD_NAME = "msg"
 )
 
 const (


### PR DESCRIPTION
EKS Host logs don't use `log `but instead use `msg`

This means our enricher plugin will end up dropping these logs.

Example:
This log is estedn in a `log` field because I had to use fluentbit to write to stdout and then fluentbit would pick up its own logs to get this result.

However looking at the actual log payload, only `message` is present and not `log`
```
"log": [
      "[18] kube.@kibana-highlighted-field@systemd@/kibana-highlighted-field@.unknown: [1684473755.290323000, {\"priority\"=>\"6\", \"syslog_facility\"=>\"3\", \"code_file\"=>\"src/core/automount.c\", \"unit\"=>\"proc-sys-fs-binfmt_misc.automount\", \"syslog_identifier\"=>\"@kibana-highlighted-field@systemd@/kibana-highlighted-field@\", \"transport\"=>\"journal\", \"pid\"=>\"1\", \"uid\"=>\"0\", \"gid\"=>\"0\", \"comm\"=>\"@kibana-highlighted-field@systemd@/kibana-highlighted-field@\", \"exe\"=>\"/usr/lib/@kibana-highlighted-field@systemd@/kibana-highlighted-field@/@kibana-highlighted-field@systemd@/kibana-highlighted-field@\", \"cmdline\"=>\"/usr/lib/@kibana-highlighted-field@systemd@/kibana-highlighted-field@/@kibana-highlighted-field@systemd@/kibana-highlighted-field@ --switched-root --system --deserialize 21\", \"cap_effective\"=>\"3fffffffff\", \"@kibana-highlighted-field@systemd@/kibana-highlighted-field@_cgroup\"=>\"/\", \"boot_id\"=>\"9d1e9122fd274bc382c0ba8cdcb48a40\", \"machine_id\"=>\"ec25a1ecc52ebdf60f2f637ed9363443\", \"hostname\"=>\"ip-10-128-192-33.ec2.internal\", \"code_line\"=>\"985\", \"code_function\"=>\"automount_dispatch_io\", \"message\"=>\"Got automount request for /proc/sys/fs/binfmt_misc, triggered by 32293 (agent)\", \"source_realtime_timestamp\"=>\"1684473755284149\"}]"
    ]
  },
```
