### PR TITLE
Add host name enrichment to fluentbit as well as tag eks host logs

### DIFF
--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -13,6 +13,7 @@ type Enricher struct {
 	CloudAccountName          string `env:"CLOUD_ACCOUNT_NAME,required"`
 	CloudRegion               string `env:"CLOUD_REGION,required"`
 	K8sClusterName            string `env:"K8S_CLUSTER_NAME,required"`
+	K8sNodeName               string `env:"K8S_NODE_NAME,required"`
 	CloudPartition            string `env:"CLOUD_PARTITION,required"`
 	CloudAccountGroupFunction string `env:"CLOUD_ACCOUNT_GROUP_FUNCTION,required"`
 	Organization              string `env:"ORGANIZATION,required"`
@@ -34,12 +35,13 @@ func NewEnricher() (*Enricher, error) {
 var _ enricher.IEnricher = (*Enricher)(nil)
 
 func (e Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[interface{}]interface{} {
-	// Drop log if "log" field is empty
-	if r[mappings.LOG_FIELD_NAME] == nil && r[mappings.MSG_FIELD_NAME] == nil {
+	// Drop log if "log" field and "message" field is empty
+	_, logOk := r[mappings.KUBERNETES_RESOURCE_FIELD_NAME]
+	_, msgOk := r[mappings.MSG_FIELD_NAME]
+	if !logOk && !msgOk {
 		return nil
 	}
-
-	// add resource attributes
+	// Add static attributes
 	r[mappings.RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
 		mappings.RESOURCE_ACCOUNT_ID:             e.CloudAccountId,
 		mappings.RESOURCE_ACCOUNT_NAME:           e.CloudAccountName,
@@ -50,18 +52,26 @@ func (e Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[i
 		mappings.RESOURCE_PLATFORM:               e.CloudPlatform,
 		mappings.RESOURCE_PROVIDER:               e.CloudProvider,
 	}
-
 	r[mappings.OBSERVED_TIMESTAMP] = t.UnixMilli()
 
-	// If Fluentbit has failed to enrich k8s metadata on the log, we insert a placeholder value for the kubernetes.service_name
-	// https://docs.google.com/document/d/1vRCUKMeo6ypnAq34iwQN7LtDsXxmlj0aYEfRofwV7A4/edit
+	// If Fluentbit has failed to enrich k8s metadata on the log, this can mean two things:
 	if _, ok := r[mappings.KUBERNETES_RESOURCE_FIELD_NAME]; !ok {
-		r[mappings.KUBERNETES_RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
-			mappings.KUBERNETES_CONTAINER_NAME: mappings.PLACEHOLDER_MISSING_KUBERNETES_METADATA,
+		// The log is a journal systemd log
+		if _, transportOk := r[mappings.TRANSPORT_FIELD_NAME]; msgOk && transportOk {
+			r[mappings.RESOURCE_FIELD_NAME].(map[interface{}]interface{})[mappings.RESOURCE_SERVICE_NAME] = "eks_host_log"
+		} else {
+			// The pod has started up and potentially died too early for us to enrich the log
+			// We insert a placeholder value for the kubernetes.container_name
+			// https://docs.google.com/document/d/1vRCUKMeo6ypnAq34iwQN7LtDsXxmlj0aYEfRofwV7A4/edit
+			r[mappings.KUBERNETES_RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
+				mappings.KUBERNETES_CONTAINER_NAME: mappings.PLACEHOLDER_MISSING_KUBERNETES_METADATA,
+			}
 		}
 	}
 
+	// Add kubernetes static attributes
 	r[mappings.KUBERNETES_RESOURCE_FIELD_NAME].(map[interface{}]interface{})[mappings.KUBERNETES_RESOURCE_CLUSTER_NAME] = e.K8sClusterName
+	r[mappings.KUBERNETES_RESOURCE_FIELD_NAME].(map[interface{}]interface{})[mappings.KUBERNETES_RESOURCE_NODE_NAME] = e.K8sNodeName
 
 	return r
 }

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -5,9 +5,10 @@ const (
 )
 
 const (
-	LOG_FIELD_NAME       = "log"
-	MSG_FIELD_NAME       = "message"
-	TRANSPORT_FIELD_NAME = "transport"
+	LOG_FIELD_NAME            = "log"
+	MESSAGE_FIELD_NAME        = "message"
+	TRANSPORT_FIELD_NAME      = "transport"
+	EKS_HOST_LOG_SERVICE_NAME = "eks_host_log"
 )
 
 const (

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -5,19 +5,22 @@ const (
 )
 
 const (
-	LOG_FIELD_NAME = "log"
-	MSG_FIELD_NAME = "message"
+	LOG_FIELD_NAME       = "log"
+	MSG_FIELD_NAME       = "message"
+	TRANSPORT_FIELD_NAME = "transport"
 )
 
 const (
 	KUBERNETES_RESOURCE_FIELD_NAME          = "kubernetes"
 	KUBERNETES_RESOURCE_CLUSTER_NAME        = "cluster.name"
 	KUBERNETES_CONTAINER_NAME               = "container_name"
+	KUBERNETES_RESOURCE_NODE_NAME           = "node.name"
 	PLACEHOLDER_MISSING_KUBERNETES_METADATA = "_missing_metadata"
 )
 
 const (
 	RESOURCE_FIELD_NAME             = "resource"
+	RESOURCE_SERVICE_NAME           = "service.name"
 	RESOURCE_PARTITION              = "cloud.partition"
 	RESOURCE_ACCOUNT_ID             = "cloud.account.id"
 	RESOURCE_ACCOUNT_NAME           = "cloud.account.name"
@@ -34,6 +37,7 @@ const (
 	ENV_REGION                 = "CLOUD_REGION"
 	ENV_ACCOUNT_GROUP_FUNCTION = "CLOUD_ACCOUNT_GROUP_FUNCTION"
 	ENV_CLUSTER_NAME           = "K8S_CLUSTER_NAME"
+	ENV_NODE_NAME              = "K8S_NODE_NAME"
 	ENV_PARTITION              = "CLOUD_PARTITION"
 	ENV_ORGANISATION           = "ORGANIZATION"
 	ENV_PLATFORM               = "CLOUD_PLATFORM"


### PR DESCRIPTION
This PR incorporates two changes:

Because of https://github.com/Canva/k8s/pull/9331, we now have host.name available as an environment var on fluentbit machines. We can now use that enrich `kubernetes.host.name` rather than relying on the `kubernetes` filter in Fluentbit to be able to do that (which our EKS host logs cant use)

Also included in this PR is a conditional block to tag `resource.service.name = eks_host_log` so that we can correctly identify which logs were collected via systemd. This is to overcome a gap with our logging pipeline enricher since both the `eks_host_enricher.py` and `eks_standard_enricher.py` will be built at the same priority and therefore logs may match the wrong enricher.
