### PR TITLE
[OLED-448] Fluent Bit: Add EKS host tags from node labels

### DIFF
--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -1,22 +1,16 @@
 package eks
 
 import (
+	"context"
 	"time"
 
 	"github.com/caarlos0/env/v7"
 	"github.com/canva/amazon-kinesis-streams-for-fluent-bit/enricher"
 	"github.com/canva/amazon-kinesis-streams-for-fluent-bit/enricher/mappings"
 	"github.com/sirupsen/logrus"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-)
-
-var (
-	_ metav1.GetOptions
-	_ kubernetes.Interface
-	_ rest.Config
 )
 
 type LogType int
@@ -33,7 +27,7 @@ type EnricherConfiguration func(*Enricher) error
 type Enricher struct {
 	metric *EnricherMetric
 
-	CloudAccountId            string `env:"CLOUD_ACCOUNT_ID,required"`
+	CloudAccountID            string `env:"CLOUD_ACCOUNT_ID,required"`
 	CloudAccountName          string `env:"CLOUD_ACCOUNT_NAME,required"`
 	CloudRegion               string `env:"CLOUD_REGION,required"`
 	K8sClusterName            string `env:"K8S_CLUSTER_NAME,required"`
@@ -43,6 +37,11 @@ type Enricher struct {
 	Organization              string `env:"ORGANIZATION,required"`
 	CloudProvider             string `env:"CLOUD_PROVIDER,required"`
 	CloudPlatform             string `env:"CLOUD_PLATFORM,required"`
+
+	hostName                  string
+	hostType                  string
+	cloudAvailabilityZoneID   string
+	cloudAvailabilityZoneName string
 }
 
 // NewEnricher returns a enricher with env vars being parsed.
@@ -61,7 +60,49 @@ func NewEnricher(cfgs ...EnricherConfiguration) (*Enricher, error) {
 		}
 	}
 
+	enricher.populateNodeLabels()
 	return enricher, nil
+}
+
+func (e *Enricher) populateNodeLabels() {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logrus.WithError(err).Error("could not get kube cluster config")
+		return
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logrus.WithError(err).WithField("config", config.String()).Error("could not instantiate kubernetes clientset")
+		return
+	}
+
+	node, err := clientset.CoreV1().Nodes().Get(context.Background(), e.K8sNodeName, metav1.GetOptions{})
+	if err != nil {
+		logrus.WithError(err).WithField("k8s.node.name", e.K8sNodeName).Error("could not get node information")
+		return
+	}
+
+	var ok bool
+	if e.hostName, ok = node.Labels[mappings.KUBERNETES_NODE_LABEL_HOST_NAME]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_HOST_NAME}
+		logrus.WithFields(fields).Warn("could not find host name label")
+	}
+
+	if e.hostType, ok = node.Labels[mappings.KUBERNETES_NODE_LABEL_HOST_TYPE]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_HOST_TYPE}
+		logrus.WithFields(fields).Warn("could not find host type label")
+	}
+
+	if e.cloudAvailabilityZoneID, ok = node.Labels[mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_ID]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_ID}
+		logrus.WithFields(fields).Warn("could not find cloud availability zone id label")
+	}
+
+	if e.cloudAvailabilityZoneName, ok = node.Labels[mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME}
+		logrus.WithFields(fields).Warn("could not find cloud availability zone name label")
+	}
 }
 
 var _ enricher.IEnricher = (*Enricher)(nil)
@@ -78,14 +119,18 @@ func (e *Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[
 
 	// Add static attributes
 	r[mappings.RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
-		mappings.RESOURCE_ACCOUNT_ID:             e.CloudAccountId,
-		mappings.RESOURCE_ACCOUNT_NAME:           e.CloudAccountName,
-		mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION: e.CloudAccountGroupFunction,
-		mappings.RESOURCE_PARTITION:              e.CloudPartition,
-		mappings.RESOURCE_REGION:                 e.CloudRegion,
-		mappings.RESOURCE_ORGANIZATION:           e.Organization,
-		mappings.RESOURCE_PLATFORM:               e.CloudPlatform,
-		mappings.RESOURCE_PROVIDER:               e.CloudProvider,
+		mappings.RESOURCE_ACCOUNT_ID:                   e.CloudAccountID,
+		mappings.RESOURCE_ACCOUNT_NAME:                 e.CloudAccountName,
+		mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION:       e.CloudAccountGroupFunction,
+		mappings.RESOURCE_PARTITION:                    e.CloudPartition,
+		mappings.RESOURCE_REGION:                       e.CloudRegion,
+		mappings.RESOURCE_ORGANIZATION:                 e.Organization,
+		mappings.RESOURCE_PLATFORM:                     e.CloudPlatform,
+		mappings.RESOURCE_PROVIDER:                     e.CloudProvider,
+		mappings.RESOURCE_HOST_NAME:                    e.hostName,
+		mappings.RESOURCE_HOST_TYPE:                    e.hostType,
+		mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_ID:   e.cloudAvailabilityZoneID,
+		mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME: e.cloudAvailabilityZoneName,
 	}
 	r[mappings.OBSERVED_TIMESTAMP] = t.UnixMilli()
 
@@ -116,7 +161,7 @@ func (e *Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[
 	return r
 }
 
-func (e Enricher) inferType(record map[interface{}]interface{}) LogType {
+func (e *Enricher) inferType(record map[interface{}]interface{}) LogType {
 	_, hasApplicationLog := record[mappings.LOG_FIELD_NAME]
 	_, hasHostMsgOk := record[mappings.MESSAGE_FIELD_NAME]
 	_, hostTransportOk := record[mappings.TRANSPORT_FIELD_NAME]

--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -44,6 +44,22 @@ type Enricher struct {
 	cloudAvailabilityZoneName string
 }
 
+func kubeClientset() (*kubernetes.Clientset, bool) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		logrus.WithError(err).Error("could not get kube cluster config")
+		return nil, false
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logrus.WithError(err).WithField("config", config.String()).Error("could not instantiate kubernetes clientset")
+		return nil, false
+	}
+
+	return clientset, true
+}
+
 // NewEnricher returns a enricher with env vars being parsed.
 // These env vars are derived from mappings.go.
 func NewEnricher(cfgs ...EnricherConfiguration) (*Enricher, error) {
@@ -60,23 +76,13 @@ func NewEnricher(cfgs ...EnricherConfiguration) (*Enricher, error) {
 		}
 	}
 
-	enricher.populateNodeLabels()
+	if clientset, ok := kubeClientset(); ok {
+		enricher.populateNodeLabels(clientset)
+	}
 	return enricher, nil
 }
 
-func (e *Enricher) populateNodeLabels() {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		logrus.WithError(err).Error("could not get kube cluster config")
-		return
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		logrus.WithError(err).WithField("config", config.String()).Error("could not instantiate kubernetes clientset")
-		return
-	}
-
+func (e *Enricher) populateNodeLabels(clientset kubernetes.Interface) {
 	node, err := clientset.CoreV1().Nodes().Get(context.Background(), e.K8sNodeName, metav1.GetOptions{})
 	if err != nil {
 		logrus.WithError(err).WithField("k8s.node.name", e.K8sNodeName).Error("could not get node information")

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -11,12 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-var (
-	_ corev1.Node
-	_ metav1.GetOptions
-	_ fake.Clientset
-)
-
 func Test_NewEnricher(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		envs := map[string]string{
@@ -48,6 +42,32 @@ func Test_NewEnricher(t *testing.T) {
 		assert.Nil(t, enricher)
 		assert.Error(t, err)
 	})
+}
+
+func Test_PopulateNodeLabels(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					mappings.KUBERNETES_NODE_LABEL_HOST_NAME:     DummyHostName,
+					mappings.KUBERNETES_NODE_LABEL_HOST_TYPE:     DummyHostType,
+					mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_ID:   DummyCloudAvailabilityZoneID,
+					mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME: DummyCloudAvailabilityZoneName,
+				},
+			},
+		},
+	)
+
+	wantedEnricher := &Enricher{
+		hostName:                  DummyHostName,
+		hostType:                  DummyHostType,
+		cloudAvailabilityZoneID:   DummyCloudAvailabilityZoneID,
+		cloudAvailabilityZoneName: DummyCloudAvailabilityZoneName,
+	}
+
+	enricher := &Enricher{}
+	enricher.populateNodeLabels(clientset)
+	assert.Equal(t, enricher, wantedEnricher)
 }
 
 func Test_EnrichRecord(t *testing.T) {

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -48,6 +48,7 @@ func Test_PopulateNodeLabels(t *testing.T) {
 	clientset := fake.NewSimpleClientset(
 		&corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
+				Name: DummyNodeName,
 				Labels: map[string]string{
 					mappings.KUBERNETES_NODE_LABEL_HOST_NAME:     DummyHostName,
 					mappings.KUBERNETES_NODE_LABEL_HOST_TYPE:     DummyHostType,
@@ -59,13 +60,14 @@ func Test_PopulateNodeLabels(t *testing.T) {
 	)
 
 	wantedEnricher := &Enricher{
+		K8sNodeName:               DummyNodeName,
 		hostName:                  DummyHostName,
 		hostType:                  DummyHostType,
 		cloudAvailabilityZoneID:   DummyCloudAvailabilityZoneID,
 		cloudAvailabilityZoneName: DummyCloudAvailabilityZoneName,
 	}
 
-	enricher := &Enricher{}
+	enricher := &Enricher{K8sNodeName: DummyNodeName}
 	enricher.populateNodeLabels(clientset)
 	assert.Equal(t, enricher, wantedEnricher)
 }

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -20,7 +20,7 @@ var (
 func Test_NewEnricher(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		envs := map[string]string{
-			mappings.ENV_ACCOUNT_ID:             DummyAccountId,
+			mappings.ENV_ACCOUNT_ID:             DummyAccountID,
 			mappings.ENV_ACCOUNT_NAME:           DummyAccountName,
 			mappings.ENV_REGION:                 DummyRegion,
 			mappings.ENV_ACCOUNT_GROUP_FUNCTION: DummyAccountGroupFunction,
@@ -64,7 +64,7 @@ func Test_EnrichRecord(t *testing.T) {
 	}
 
 	defaultEnricher := Enricher{
-		CloudAccountId:            DummyAccountId,
+		CloudAccountID:            DummyAccountID,
 		CloudAccountName:          DummyAccountName,
 		CloudRegion:               DummyRegion,
 		CloudPartition:            DummyPartition,
@@ -74,19 +74,27 @@ func Test_EnrichRecord(t *testing.T) {
 		CloudProvider:             DummyProvider,
 		CloudPlatform:             DummyProvider,
 		Organization:              DummyOrganization,
+		hostName:                  DummyHostName,
+		hostType:                  DummyHostType,
+		cloudAvailabilityZoneID:   DummyCloudAvailabilityZoneID,
+		cloudAvailabilityZoneName: DummyCloudAvailabilityZoneName,
 	}
 
 	defaultExpectedWithLog := map[interface{}]interface{}{
 		mappings.LOG_FIELD_NAME: dummyLog,
 		mappings.RESOURCE_FIELD_NAME: map[interface{}]interface{}{
-			mappings.RESOURCE_ACCOUNT_ID:             defaultEnricher.CloudAccountId,
-			mappings.RESOURCE_ACCOUNT_NAME:           defaultEnricher.CloudAccountName,
-			mappings.RESOURCE_REGION:                 defaultEnricher.CloudRegion,
-			mappings.RESOURCE_PARTITION:              defaultEnricher.CloudPartition,
-			mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION: defaultEnricher.CloudAccountGroupFunction,
-			mappings.RESOURCE_ORGANIZATION:           defaultEnricher.Organization,
-			mappings.RESOURCE_PLATFORM:               defaultEnricher.CloudPlatform,
-			mappings.RESOURCE_PROVIDER:               defaultEnricher.CloudProvider,
+			mappings.RESOURCE_ACCOUNT_ID:                   defaultEnricher.CloudAccountID,
+			mappings.RESOURCE_ACCOUNT_NAME:                 defaultEnricher.CloudAccountName,
+			mappings.RESOURCE_REGION:                       defaultEnricher.CloudRegion,
+			mappings.RESOURCE_PARTITION:                    defaultEnricher.CloudPartition,
+			mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION:       defaultEnricher.CloudAccountGroupFunction,
+			mappings.RESOURCE_ORGANIZATION:                 defaultEnricher.Organization,
+			mappings.RESOURCE_PLATFORM:                     defaultEnricher.CloudPlatform,
+			mappings.RESOURCE_PROVIDER:                     defaultEnricher.CloudProvider,
+			mappings.RESOURCE_HOST_NAME:                    defaultEnricher.hostName,
+			mappings.RESOURCE_HOST_TYPE:                    defaultEnricher.hostType,
+			mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_ID:   defaultEnricher.cloudAvailabilityZoneID,
+			mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME: defaultEnricher.cloudAvailabilityZoneName,
 		},
 		mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 			"key": "value",
@@ -206,15 +214,19 @@ func Test_EnrichRecord(t *testing.T) {
 					mappings.KUBERNETES_RESOURCE_CLUSTER_NAME: defaultEnricher.K8sClusterName,
 				}
 				expected[mappings.RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
-					mappings.RESOURCE_ACCOUNT_ID:             defaultEnricher.CloudAccountId,
-					mappings.RESOURCE_ACCOUNT_NAME:           defaultEnricher.CloudAccountName,
-					mappings.RESOURCE_REGION:                 defaultEnricher.CloudRegion,
-					mappings.RESOURCE_PARTITION:              defaultEnricher.CloudPartition,
-					mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION: defaultEnricher.CloudAccountGroupFunction,
-					mappings.RESOURCE_ORGANIZATION:           defaultEnricher.Organization,
-					mappings.RESOURCE_PLATFORM:               defaultEnricher.CloudPlatform,
-					mappings.RESOURCE_PROVIDER:               defaultEnricher.CloudProvider,
-					mappings.RESOURCE_SERVICE_NAME:           mappings.EKS_HOST_LOG_SERVICE_NAME,
+					mappings.RESOURCE_ACCOUNT_ID:                   defaultEnricher.CloudAccountID,
+					mappings.RESOURCE_ACCOUNT_NAME:                 defaultEnricher.CloudAccountName,
+					mappings.RESOURCE_REGION:                       defaultEnricher.CloudRegion,
+					mappings.RESOURCE_PARTITION:                    defaultEnricher.CloudPartition,
+					mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION:       defaultEnricher.CloudAccountGroupFunction,
+					mappings.RESOURCE_ORGANIZATION:                 defaultEnricher.Organization,
+					mappings.RESOURCE_PLATFORM:                     defaultEnricher.CloudPlatform,
+					mappings.RESOURCE_PROVIDER:                     defaultEnricher.CloudProvider,
+					mappings.RESOURCE_SERVICE_NAME:                 mappings.EKS_HOST_LOG_SERVICE_NAME,
+					mappings.RESOURCE_HOST_NAME:                    defaultEnricher.hostName,
+					mappings.RESOURCE_HOST_TYPE:                    defaultEnricher.hostType,
+					mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_ID:   defaultEnricher.cloudAvailabilityZoneID,
+					mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME: defaultEnricher.cloudAvailabilityZoneName,
 				}
 				return expected
 			}(),
@@ -230,17 +242,21 @@ func Test_EnrichRecord(t *testing.T) {
 }
 
 var (
-	DummyAccountId            = "123123123"
-	DummyAccountName          = "Account Name"
-	DummyRegion               = "ap-southeast-1"
-	DummyAccountGroupFunction = "general"
-	DummyClusterName          = "Cluster Name"
-	DummyNodeName             = "node_name"
-	DummyPartition            = "aws"
-	DummyOrganization         = "canva"
-	DummyProvider             = "aws"
-	DummyPlatform             = "eks"
-	DummyTime                 = time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC)
+	DummyAccountID                 = "123123123"
+	DummyAccountName               = "Account Name"
+	DummyRegion                    = "ap-southeast-1"
+	DummyAccountGroupFunction      = "general"
+	DummyClusterName               = "Cluster Name"
+	DummyNodeName                  = "node_name"
+	DummyPartition                 = "aws"
+	DummyOrganization              = "canva"
+	DummyProvider                  = "aws"
+	DummyPlatform                  = "eks"
+	DummyTime                      = time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC)
+	DummyHostName                  = "public-otel-gateway-7b88c59dcf-26lfq"
+	DummyHostType                  = "c7i.4xlarge"
+	DummyCloudAvailabilityZoneID   = "apse2-az1"
+	DummyCloudAvailabilityZoneName = "ap-southeast-2a"
 )
 
 var (

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -22,18 +22,29 @@ const (
 )
 
 const (
-	RESOURCE_APPLICATION_ID         = "application_id"
-	RESOURCE_FIELD_NAME             = "resource"
-	RESOURCE_SERVICE_NAME           = "service.name"
-	RESOURCE_PARTITION              = "cloud.partition"
-	RESOURCE_ACCOUNT_ID             = "cloud.account.id"
-	RESOURCE_ACCOUNT_NAME           = "cloud.account.name"
-	RESOURCE_REGION                 = "cloud.region"
-	RESOURCE_ACCOUNT_GROUP_FUNCTION = "cloud.account.function"
-	RESOURCE_ORGANIZATION           = "organization"
-	RESOURCE_PLATFORM               = "cloud.platform"
-	RESOURCE_PROVIDER               = "cloud.provider"
-	RESOURCE_COMPONENT              = "component"
+	KUBERNETES_NODE_LABEL_HOST_NAME     = "kubernetes.io/hostname"
+	KUBERNETES_NODE_LABEL_HOST_TYPE     = "node.kubernetes.io/instance-type"
+	KUBERNETES_NODE_LABEL_CLOUD_AZ_ID   = "topology.k8s.aws/zone-id"
+	KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME = "topology.kubernetes.io/zone"
+)
+
+const (
+	RESOURCE_APPLICATION_ID               = "application_id"
+	RESOURCE_FIELD_NAME                   = "resource"
+	RESOURCE_SERVICE_NAME                 = "service.name"
+	RESOURCE_PARTITION                    = "cloud.partition"
+	RESOURCE_ACCOUNT_ID                   = "cloud.account.id"
+	RESOURCE_ACCOUNT_NAME                 = "cloud.account.name"
+	RESOURCE_REGION                       = "cloud.region"
+	RESOURCE_ACCOUNT_GROUP_FUNCTION       = "cloud.account.function"
+	RESOURCE_ORGANIZATION                 = "organization"
+	RESOURCE_PLATFORM                     = "cloud.platform"
+	RESOURCE_PROVIDER                     = "cloud.provider"
+	RESOURCE_COMPONENT                    = "component"
+	RESOURCE_HOST_NAME                    = "host.name"
+	RESOURCE_HOST_TYPE                    = "host.type"
+	RESOURCE_CLOUD_AVAILABILITY_ZONE_ID   = "cloud.availability_zone.id"
+	RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME = "cloud.availability_zone.name"
 )
 
 const (


### PR DESCRIPTION
V2 which doesn't add the Go Kube client here: https://github.com/Canva/amazon-kinesis-streams-for-fluent-bit/pull/29

## Context
There are some tags in metrics which are populated from node labels which are not populated in logs.

## Description
Add the Go Kubernetes client to be able to interact with the Kubernetes API.

In the enricher, add a function which is called when the client is created to pull the node information using the Kubernetes API and populate the `host.name`, `host.type`, `cloud.availability_zone.id` and `cloud.availability_zone.name` tags. Note: `host.id` tag is not available in metrics, so I also have not supported the tag in logs.

## Note
There's a lot of changes in the `/vendors` directory. They seem to have been pulled in because I added the Go client for Kubernetes. These changes have been put into #30.

~~I haven't been able to test this locally due to errors with running the `build_plugin` step locally. I'll have another go next week.~~

I was able to test it locally. It does seem to run correctly, though I didn't connect it to Kinesis