### PR TITLE
[OLED-448] Fluent Bit: Add EKS host tags from node labels with own Kube client

### DIFF
--- a/enricher/eks/eks.go
+++ b/enricher/eks/eks.go
@@ -23,7 +23,7 @@ type EnricherConfiguration func(*Enricher) error
 type Enricher struct {
 	metric *EnricherMetric
 
-	CloudAccountId            string `env:"CLOUD_ACCOUNT_ID,required"`
+	CloudAccountID            string `env:"CLOUD_ACCOUNT_ID,required"`
 	CloudAccountName          string `env:"CLOUD_ACCOUNT_NAME,required"`
 	CloudRegion               string `env:"CLOUD_REGION,required"`
 	K8sClusterName            string `env:"K8S_CLUSTER_NAME,required"`
@@ -33,6 +33,11 @@ type Enricher struct {
 	Organization              string `env:"ORGANIZATION,required"`
 	CloudProvider             string `env:"CLOUD_PROVIDER,required"`
 	CloudPlatform             string `env:"CLOUD_PLATFORM,required"`
+
+	hostName                  string
+	hostType                  string
+	cloudAvailabilityZoneID   string
+	cloudAvailabilityZoneName string
 }
 
 // NewEnricher returns a enricher with env vars being parsed.
@@ -51,7 +56,43 @@ func NewEnricher(cfgs ...EnricherConfiguration) (*Enricher, error) {
 		}
 	}
 
+	enricher.populateNodeLabels()
 	return enricher, nil
+}
+
+func (e *Enricher) populateNodeLabels() {
+	client, err := newKubeClient()
+	if err != nil {
+		logrus.WithError(err).Error("could not instantiate Kubernetes client")
+		return
+	}
+
+	nodeLabels, err := client.getNodeLabels(e.K8sNodeName)
+	if err != nil {
+		logrus.WithError(err).WithField("k8s.node.name", e.K8sNodeName).Error("could not get node information")
+		return
+	}
+
+	var ok bool
+	if e.hostName, ok = nodeLabels[mappings.KUBERNETES_NODE_LABEL_HOST_NAME]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_HOST_NAME}
+		logrus.WithFields(fields).Warn("could not find host name label")
+	}
+
+	if e.hostType, ok = nodeLabels[mappings.KUBERNETES_NODE_LABEL_HOST_TYPE]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_HOST_TYPE}
+		logrus.WithFields(fields).Warn("could not find host type label")
+	}
+
+	if e.cloudAvailabilityZoneID, ok = nodeLabels[mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_ID]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_ID}
+		logrus.WithFields(fields).Warn("could not find cloud availability zone id label")
+	}
+
+	if e.cloudAvailabilityZoneName, ok = nodeLabels[mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME]; !ok {
+		fields := logrus.Fields{"k8s.node.name": e.K8sNodeName, "label": mappings.KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME}
+		logrus.WithFields(fields).Warn("could not find cloud availability zone name label")
+	}
 }
 
 var _ enricher.IEnricher = (*Enricher)(nil)
@@ -68,14 +109,18 @@ func (e *Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[
 
 	// Add static attributes
 	r[mappings.RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
-		mappings.RESOURCE_ACCOUNT_ID:             e.CloudAccountId,
-		mappings.RESOURCE_ACCOUNT_NAME:           e.CloudAccountName,
-		mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION: e.CloudAccountGroupFunction,
-		mappings.RESOURCE_PARTITION:              e.CloudPartition,
-		mappings.RESOURCE_REGION:                 e.CloudRegion,
-		mappings.RESOURCE_ORGANIZATION:           e.Organization,
-		mappings.RESOURCE_PLATFORM:               e.CloudPlatform,
-		mappings.RESOURCE_PROVIDER:               e.CloudProvider,
+		mappings.RESOURCE_ACCOUNT_ID:                   e.CloudAccountID,
+		mappings.RESOURCE_ACCOUNT_NAME:                 e.CloudAccountName,
+		mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION:       e.CloudAccountGroupFunction,
+		mappings.RESOURCE_PARTITION:                    e.CloudPartition,
+		mappings.RESOURCE_REGION:                       e.CloudRegion,
+		mappings.RESOURCE_ORGANIZATION:                 e.Organization,
+		mappings.RESOURCE_PLATFORM:                     e.CloudPlatform,
+		mappings.RESOURCE_PROVIDER:                     e.CloudProvider,
+		mappings.RESOURCE_HOST_NAME:                    e.hostName,
+		mappings.RESOURCE_HOST_TYPE:                    e.hostType,
+		mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_ID:   e.cloudAvailabilityZoneID,
+		mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME: e.cloudAvailabilityZoneName,
 	}
 	r[mappings.OBSERVED_TIMESTAMP] = t.UnixMilli()
 
@@ -106,7 +151,7 @@ func (e *Enricher) EnrichRecord(r map[interface{}]interface{}, t time.Time) map[
 	return r
 }
 
-func (e Enricher) inferType(record map[interface{}]interface{}) LogType {
+func (e *Enricher) inferType(record map[interface{}]interface{}) LogType {
 	_, hasApplicationLog := record[mappings.LOG_FIELD_NAME]
 	_, hasHostMsgOk := record[mappings.MESSAGE_FIELD_NAME]
 	_, hostTransportOk := record[mappings.TRANSPORT_FIELD_NAME]

--- a/enricher/eks/eks_test.go
+++ b/enricher/eks/eks_test.go
@@ -11,7 +11,7 @@ import (
 func Test_NewEnricher(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		envs := map[string]string{
-			mappings.ENV_ACCOUNT_ID:             DummyAccountId,
+			mappings.ENV_ACCOUNT_ID:             DummyAccountID,
 			mappings.ENV_ACCOUNT_NAME:           DummyAccountName,
 			mappings.ENV_REGION:                 DummyRegion,
 			mappings.ENV_ACCOUNT_GROUP_FUNCTION: DummyAccountGroupFunction,
@@ -55,7 +55,7 @@ func Test_EnrichRecord(t *testing.T) {
 	}
 
 	defaultEnricher := Enricher{
-		CloudAccountId:            DummyAccountId,
+		CloudAccountID:            DummyAccountID,
 		CloudAccountName:          DummyAccountName,
 		CloudRegion:               DummyRegion,
 		CloudPartition:            DummyPartition,
@@ -65,19 +65,27 @@ func Test_EnrichRecord(t *testing.T) {
 		CloudProvider:             DummyProvider,
 		CloudPlatform:             DummyProvider,
 		Organization:              DummyOrganization,
+		hostName:                  DummyHostName,
+		hostType:                  DummyHostType,
+		cloudAvailabilityZoneID:   DummyCloudAvailabilityZoneID,
+		cloudAvailabilityZoneName: DummyCloudAvailabilityZoneName,
 	}
 
 	defaultExpectedWithLog := map[interface{}]interface{}{
 		mappings.LOG_FIELD_NAME: dummyLog,
 		mappings.RESOURCE_FIELD_NAME: map[interface{}]interface{}{
-			mappings.RESOURCE_ACCOUNT_ID:             defaultEnricher.CloudAccountId,
-			mappings.RESOURCE_ACCOUNT_NAME:           defaultEnricher.CloudAccountName,
-			mappings.RESOURCE_REGION:                 defaultEnricher.CloudRegion,
-			mappings.RESOURCE_PARTITION:              defaultEnricher.CloudPartition,
-			mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION: defaultEnricher.CloudAccountGroupFunction,
-			mappings.RESOURCE_ORGANIZATION:           defaultEnricher.Organization,
-			mappings.RESOURCE_PLATFORM:               defaultEnricher.CloudPlatform,
-			mappings.RESOURCE_PROVIDER:               defaultEnricher.CloudProvider,
+			mappings.RESOURCE_ACCOUNT_ID:                   defaultEnricher.CloudAccountID,
+			mappings.RESOURCE_ACCOUNT_NAME:                 defaultEnricher.CloudAccountName,
+			mappings.RESOURCE_REGION:                       defaultEnricher.CloudRegion,
+			mappings.RESOURCE_PARTITION:                    defaultEnricher.CloudPartition,
+			mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION:       defaultEnricher.CloudAccountGroupFunction,
+			mappings.RESOURCE_ORGANIZATION:                 defaultEnricher.Organization,
+			mappings.RESOURCE_PLATFORM:                     defaultEnricher.CloudPlatform,
+			mappings.RESOURCE_PROVIDER:                     defaultEnricher.CloudProvider,
+			mappings.RESOURCE_HOST_NAME:                    defaultEnricher.hostName,
+			mappings.RESOURCE_HOST_TYPE:                    defaultEnricher.hostType,
+			mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_ID:   defaultEnricher.cloudAvailabilityZoneID,
+			mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME: defaultEnricher.cloudAvailabilityZoneName,
 		},
 		mappings.KUBERNETES_RESOURCE_FIELD_NAME: map[interface{}]interface{}{
 			"key": "value",
@@ -197,15 +205,19 @@ func Test_EnrichRecord(t *testing.T) {
 					mappings.KUBERNETES_RESOURCE_CLUSTER_NAME: defaultEnricher.K8sClusterName,
 				}
 				expected[mappings.RESOURCE_FIELD_NAME] = map[interface{}]interface{}{
-					mappings.RESOURCE_ACCOUNT_ID:             defaultEnricher.CloudAccountId,
-					mappings.RESOURCE_ACCOUNT_NAME:           defaultEnricher.CloudAccountName,
-					mappings.RESOURCE_REGION:                 defaultEnricher.CloudRegion,
-					mappings.RESOURCE_PARTITION:              defaultEnricher.CloudPartition,
-					mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION: defaultEnricher.CloudAccountGroupFunction,
-					mappings.RESOURCE_ORGANIZATION:           defaultEnricher.Organization,
-					mappings.RESOURCE_PLATFORM:               defaultEnricher.CloudPlatform,
-					mappings.RESOURCE_PROVIDER:               defaultEnricher.CloudProvider,
-					mappings.RESOURCE_SERVICE_NAME:           mappings.EKS_HOST_LOG_SERVICE_NAME,
+					mappings.RESOURCE_ACCOUNT_ID:                   defaultEnricher.CloudAccountID,
+					mappings.RESOURCE_ACCOUNT_NAME:                 defaultEnricher.CloudAccountName,
+					mappings.RESOURCE_REGION:                       defaultEnricher.CloudRegion,
+					mappings.RESOURCE_PARTITION:                    defaultEnricher.CloudPartition,
+					mappings.RESOURCE_ACCOUNT_GROUP_FUNCTION:       defaultEnricher.CloudAccountGroupFunction,
+					mappings.RESOURCE_ORGANIZATION:                 defaultEnricher.Organization,
+					mappings.RESOURCE_PLATFORM:                     defaultEnricher.CloudPlatform,
+					mappings.RESOURCE_PROVIDER:                     defaultEnricher.CloudProvider,
+					mappings.RESOURCE_SERVICE_NAME:                 mappings.EKS_HOST_LOG_SERVICE_NAME,
+					mappings.RESOURCE_HOST_NAME:                    defaultEnricher.hostName,
+					mappings.RESOURCE_HOST_TYPE:                    defaultEnricher.hostType,
+					mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_ID:   defaultEnricher.cloudAvailabilityZoneID,
+					mappings.RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME: defaultEnricher.cloudAvailabilityZoneName,
 				}
 				return expected
 			}(),
@@ -221,17 +233,21 @@ func Test_EnrichRecord(t *testing.T) {
 }
 
 var (
-	DummyAccountId            = "123123123"
-	DummyAccountName          = "Account Name"
-	DummyRegion               = "ap-southeast-1"
-	DummyAccountGroupFunction = "general"
-	DummyClusterName          = "Cluster Name"
-	DummyNodeName             = "node_name"
-	DummyPartition            = "aws"
-	DummyOrganization         = "canva"
-	DummyProvider             = "aws"
-	DummyPlatform             = "eks"
-	DummyTime                 = time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC)
+	DummyAccountID                 = "123123123"
+	DummyAccountName               = "Account Name"
+	DummyRegion                    = "ap-southeast-1"
+	DummyAccountGroupFunction      = "general"
+	DummyClusterName               = "Cluster Name"
+	DummyNodeName                  = "node_name"
+	DummyPartition                 = "aws"
+	DummyOrganization              = "canva"
+	DummyProvider                  = "aws"
+	DummyPlatform                  = "eks"
+	DummyTime                      = time.Date(2009, time.November, 10, 23, 7, 5, 432000000, time.UTC)
+	DummyHostName                  = "public-otel-gateway-7b88c59dcf-26lfq"
+	DummyHostType                  = "c7i.4xlarge"
+	DummyCloudAvailabilityZoneID   = "apse2-az1"
+	DummyCloudAvailabilityZoneName = "ap-southeast-2a"
 )
 
 var (

--- a/enricher/eks/kube_client.go
+++ b/enricher/eks/kube_client.go
@@ -1,0 +1,94 @@
+package eks
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+type node struct {
+	Metadata nodeMetadata `json:"metadata"`
+}
+
+type nodeMetadata struct {
+	Labels map[string]string `json:"labels"`
+}
+
+type kubeClient struct {
+	client      *http.Client
+	host        string
+	bearerToken string
+}
+
+func newKubeClient() (*kubeClient, error) {
+	const (
+		tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	)
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if len(host) == 0 || len(port) == 0 {
+		return nil, errors.New("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
+	}
+
+	token, err := os.ReadFile(tokenFile)
+	if err != nil {
+		return nil, err
+	}
+
+	caCert, err := os.ReadFile(rootCAFile)
+	if err != nil {
+		return nil, err
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, errors.New("could load certs from CA file")
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		},
+	}
+
+	return &kubeClient{client: client, host: "https://" + net.JoinHostPort(host, port), bearerToken: string(token)}, nil
+}
+
+func (c *kubeClient) getNodeLabels(name string) (map[string]string, error) {
+	endpoint, err := url.JoinPath(c.host, "api/v1/nodes", name)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+c.bearerToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %d %s", resp.StatusCode, resp.Status)
+	}
+
+	var n node
+	if err := json.NewDecoder(resp.Body).Decode(&n); err != nil {
+		return nil, err
+	}
+
+	return n.Metadata.Labels, nil
+}

--- a/enricher/mappings/mappings.go
+++ b/enricher/mappings/mappings.go
@@ -22,18 +22,29 @@ const (
 )
 
 const (
-	RESOURCE_APPLICATION_ID         = "application_id"
-	RESOURCE_FIELD_NAME             = "resource"
-	RESOURCE_SERVICE_NAME           = "service.name"
-	RESOURCE_PARTITION              = "cloud.partition"
-	RESOURCE_ACCOUNT_ID             = "cloud.account.id"
-	RESOURCE_ACCOUNT_NAME           = "cloud.account.name"
-	RESOURCE_REGION                 = "cloud.region"
-	RESOURCE_ACCOUNT_GROUP_FUNCTION = "cloud.account.function"
-	RESOURCE_ORGANIZATION           = "organization"
-	RESOURCE_PLATFORM               = "cloud.platform"
-	RESOURCE_PROVIDER               = "cloud.provider"
-	RESOURCE_COMPONENT              = "component"
+	KUBERNETES_NODE_LABEL_HOST_NAME     = "kubernetes.io/hostname"
+	KUBERNETES_NODE_LABEL_HOST_TYPE     = "node.kubernetes.io/instance-type"
+	KUBERNETES_NODE_LABEL_CLOUD_AZ_ID   = "topology.k8s.aws/zone-id"
+	KUBERNETES_NODE_LABEL_CLOUD_AZ_NAME = "topology.kubernetes.io/zone"
+)
+
+const (
+	RESOURCE_APPLICATION_ID               = "application_id"
+	RESOURCE_FIELD_NAME                   = "resource"
+	RESOURCE_SERVICE_NAME                 = "service.name"
+	RESOURCE_PARTITION                    = "cloud.partition"
+	RESOURCE_ACCOUNT_ID                   = "cloud.account.id"
+	RESOURCE_ACCOUNT_NAME                 = "cloud.account.name"
+	RESOURCE_REGION                       = "cloud.region"
+	RESOURCE_ACCOUNT_GROUP_FUNCTION       = "cloud.account.function"
+	RESOURCE_ORGANIZATION                 = "organization"
+	RESOURCE_PLATFORM                     = "cloud.platform"
+	RESOURCE_PROVIDER                     = "cloud.provider"
+	RESOURCE_COMPONENT                    = "component"
+	RESOURCE_HOST_NAME                    = "host.name"
+	RESOURCE_HOST_TYPE                    = "host.type"
+	RESOURCE_CLOUD_AVAILABILITY_ZONE_ID   = "cloud.availability_zone.id"
+	RESOURCE_CLOUD_AVAILABILITY_ZONE_NAME = "cloud.availability_zone.name"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canva/amazon-kinesis-streams-for-fluent-bit
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/aws/amazon-kinesis-firehose-for-fluent-bit v1.7.2
@@ -31,7 +31,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,9 @@ github.com/lestrrat-go/strftime v1.1.1/go.mod h1:YDrzHJAODYQ+xxvrn5SG01uFIQAeDTz
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
+github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/vendor/github.com/modern-go/reflect2/safe_type.go
+++ b/vendor/github.com/modern-go/reflect2/safe_type.go
@@ -6,9 +6,11 @@ import (
 )
 
 type safeType struct {
-	reflect.Type
-	cfg *frozenConfig
+	Type reflect.Type
+	cfg  *frozenConfig
 }
+
+var _ Type = &safeType{}
 
 func (type2 *safeType) New() interface{} {
 	return reflect.New(type2.Type).Interface()
@@ -16,6 +18,22 @@ func (type2 *safeType) New() interface{} {
 
 func (type2 *safeType) UnsafeNew() unsafe.Pointer {
 	panic("does not support unsafe operation")
+}
+
+func (type2 *safeType) Kind() reflect.Kind {
+	return type2.Type.Kind()
+}
+
+func (type2 *safeType) Len() int {
+	return type2.Type.Len()
+}
+
+func (type2 *safeType) NumField() int {
+	return type2.Type.NumField()
+}
+
+func (type2 *safeType) String() string {
+	return type2.Type.String()
 }
 
 func (type2 *safeType) Elem() Type {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -101,7 +101,7 @@ github.com/lestrrat-go/strftime
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 ## explicit
 github.com/modern-go/concurrent
-# github.com/modern-go/reflect2 v1.0.2
+# github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee
 ## explicit; go 1.12
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822


### PR DESCRIPTION
## Context
There are some tags in metrics which are populated from node labels which are not populated in logs.

## Description
Write a small Kubernetes API client which pulls the node labels.

In the enricher, add a function which is called when the enricher is created to pull the node information using the Kubernetes API and populate the `host.name`, `host.type`, `cloud.availability_zone.id` and `cloud.availability_zone.name` tags. Note: `host.id` tag is not available in metrics, so I also have not supported the tag in logs.

## Note
I was able to test it locally. It does seem to run correctly, though I didn't connect it to Kinesis

This is an alternate option instead of https://github.com/Canva/amazon-kinesis-streams-for-fluent-bit/pull/28