### PR TITLE
Upgrade Github Actions Golang version to 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.25
+    - name: Set up Go 1.26
       uses: actions/setup-go@v2
       with:
-        go-version: '1.25'
+        go-version: '1.26'
       id: go
 
     - name: Update apt


### PR DESCRIPTION
## Context

Github actions have been failing since we've upgraded the Golang version to 1.26 without upgrading the version in `build.yml` despite the tests passing:
- https://github.com/Canva/amazon-kinesis-streams-for-fluent-bit/actions/runs/28495692209/job/84461354859?pr=30
- https://github.com/Canva/amazon-kinesis-streams-for-fluent-bit/actions/runs/28072245690/job/83109046192

## Intent

Upgrade the Go version to 1.26 in `build.yml` to match what's being used in the repo